### PR TITLE
feat: change TrackPageView to be standalone component

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ import { TrackClick, TrackPageView, TrackImpression } from '@datanova/react';
 
 function HomePage() {
   return (
-    <TrackPageView name="home_page">
+    <>
+      <TrackPageView eventName="home_page_viewed" />
+
       <TrackImpression name="hero_banner" data={{ variant: 'A' }}>
         <div>Your banner content</div>
       </TrackImpression>
@@ -56,7 +58,7 @@ function HomePage() {
       <TrackClick name="cta_button" data={{ location: 'hero' }}>
         <button>Click Me!</button>
       </TrackClick>
-    </TrackPageView>
+    </>
   );
 }
 ```
@@ -84,7 +86,10 @@ function Feature() {
 Tracks page views automatically when the component mounts.
 
 ```jsx
-<TrackPageView name="product_page" data={{ productId: '123', category: 'electronics' }} />
+<TrackPageView
+  eventName="product_page_viewed"
+  properties={{ productId: '123', category: 'electronics' }}
+/>
 ```
 
 #### `<TrackClick />`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datanova/react",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datanova/react",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@datanova/browser": "^1.3.2",

--- a/src/components/TrackPageView.tsx
+++ b/src/components/TrackPageView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useDatanova } from '../hooks/useDatanova';
 
 /**
@@ -11,7 +11,6 @@ export interface TrackPageViewProps {
   eventName: string;
   /** Optional properties to include with the event */
   properties?: Record<string, unknown>;
-  children?: ReactNode;
 }
 
 /**
@@ -24,9 +23,10 @@ export interface TrackPageViewProps {
  *
  * function HomePage() {
  *   return (
- *     <TrackPageView eventName="Home Page Viewed">
+ *     <>
+ *       <TrackPageView eventName="Home Page Viewed" />
  *       <h1>Welcome to our site</h1>
- *     </TrackPageView>
+ *     </>
  *   );
  * }
  * ```
@@ -34,20 +34,25 @@ export interface TrackPageViewProps {
  * @example
  * ```jsx
  * // With additional properties
- * <TrackPageView
- *   eventName="Product Page Viewed"
- *   properties={{ productId: '123', category: 'electronics' }}
- * >
- *   <ProductDetails />
- * </TrackPageView>
+ * function ProductPage({ productId }) {
+ *   return (
+ *     <>
+ *       <TrackPageView
+ *         eventName="Product Page Viewed"
+ *         properties={{ productId, category: 'electronics' }}
+ *       />
+ *       <ProductDetails />
+ *     </>
+ *   );
+ * }
  * ```
  */
-export function TrackPageView({ eventName, properties, children }: TrackPageViewProps) {
+export function TrackPageView({ eventName, properties }: TrackPageViewProps) {
   const { trackPageView } = useDatanova();
 
   useEffect(() => {
     trackPageView(eventName, properties);
   }, [eventName, properties, trackPageView]);
 
-  return <>{children}</>;
+  return null;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples for the `TrackPageView` component to reflect new prop names and usage patterns.

* **Refactor**
  * Simplified the `TrackPageView` component by removing support for rendering children. The component now only tracks page view events on mount and no longer renders any children.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->